### PR TITLE
fix(sleep) : sleep ne s'active plus inutilement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## Release History
 
 
+### [2.0.1] - 2026-05-26
+### Changed
+- le sleep ne s'active plus lors des `$step` - `$show_latest` premières étapes ([#68](https://github.com/ZairKSM/ono-JYFR/issues/68))
 
 ### [2.0.0] - 2026-04-15
 ### Added

--- a/src/lib/concrete_ono_module.ml
+++ b/src/lib/concrete_ono_module.ml
@@ -38,12 +38,19 @@ let get_show_latest () : (Kdo.Concrete.I32.t, _) Result.t =
   let show_latest = match !show_latest_number with Some n -> n | None -> -1 in
   Ok (Kdo.Concrete.I32.of_int32 (Int32.of_int show_latest))
 
+let sleep_cpt = ref 0
+
 (* atendre ms milliseconde *)
 let sleep (ms : Kdo.Concrete.I32.t) : (unit, _) Result.t =
   let ms = Kdo.Concrete.I32.to_int ms in
   let seconds = float_of_int ms /. 1000.0 in
-  (* si on doit montrer les x derniers on fait pas de sleep car faignon*)
-  if !show_latest_number == None then Unix.sleepf seconds;
+  incr sleep_cpt;
+  let should_sleep =
+    match (!show_latest_number, !steps_limit) with
+    | Some latest, Some total -> !sleep_cpt > total - latest
+    | _ -> true
+  in
+  if should_sleep then Unix.sleepf seconds;
   Ok ()
 
 (* Affiche une cellule vivante ou morte


### PR DESCRIPTION
sleep ne s'active plus quand l'étape actuel est inférieur à l'option show_latest #68